### PR TITLE
Ported library

### DIFF
--- a/common-test.dotty/src/main/scala/org/scalatest/SharedHelpers.scala
+++ b/common-test.dotty/src/main/scala/org/scalatest/SharedHelpers.scala
@@ -1769,7 +1769,9 @@ object SharedHelpers extends Assertions with LineNumberHelper {
   // This gives a comparator that compares based on the value in the passed in order map
   private def orderMapComparator[T](orderMap: Map[T, Int]): java.util.Comparator[T] =
     new java.util.Comparator[T] {
-      def compare(x: T, y: T): Int = {
+      def compare(_x: T | Null, _y: T | Null): Int = {
+          val x = _x.nn
+          val y = _y.nn
           // When both x and y is defined in order map, use its corresponding value to compare (which in usage below, is the index of the insertion order)
           if (orderMap.get(x).isDefined && orderMap.get(y).isDefined)
             orderMap(x) compare orderMap(y)
@@ -1802,18 +1804,18 @@ object SharedHelpers extends Assertions with LineNumberHelper {
   def sortedSet[T](elements: T*): SortedSet[T] = {
     val orderMap = Map.empty[T, Int] ++ elements.zipWithIndex
     val comparator = orderMapComparator(orderMap)
-    implicit val ordering: Ordering[T] = new Ordering[T] {
-      def compare(x: T, y: T): Int = comparator.compare(x, y)
-    }
+    implicit val ordering: Ordering[T] = (new Ordering[T | Null] {
+      def compare(x: T | Null, y: T | Null): Int = comparator.compare(x, y)
+    }).asInstanceOf[Ordering[T]]
     SortedSet.empty[T] ++ elements
   }
 
   def sortedMap[K, V](elements: (K, V)*): SortedMap[K, V] = {
     val orderMap = Map.empty[K, Int] ++ elements.map(_._1).zipWithIndex
     val comparator = orderMapComparator(orderMap)
-    implicit val ordering: Ordering[K]  = new Ordering[K] {
-      def compare(x: K, y: K): Int = comparator.compare(x, y)
-    }
+    implicit val ordering: Ordering[K]  = (new Ordering[K | Null] {
+      def compare(x: K | Null, y: K | Null): Int = comparator.compare(x, y)
+    }).asInstanceOf[Ordering[K]]
     SortedMap.empty[K, V] ++ elements
   }
 

--- a/scalactic-test/src/test/scala/org/scalactic/AccumulationSpec.scala
+++ b/scalactic-test/src/test/scala/org/scalactic/AccumulationSpec.scala
@@ -30,7 +30,7 @@ class AccumulationSpec extends UnitSpec with Accumulation with TypeCheckedTriple
   def parseDate(in: String): Date Or One[ErrorMessage] = {
     val regex = "\\d\\d\\d\\d-\\d\\d?-\\d\\d?".r
     if (regex.pattern.matcher(in).matches()) {
-      val tokens = in.split("-")
+      val tokens = in.split("-").map(_.nn)
       val year = tokens(0).toInt
       val month = tokens(1).toInt
       val dateInMonth = tokens(2).toInt
@@ -46,7 +46,7 @@ class AccumulationSpec extends UnitSpec with Accumulation with TypeCheckedTriple
   }
 
   def parseAddress(in: String): List[String] Or One[ErrorMessage] = {
-    val address = in.split(",\\s*")
+    val address = in.split(",\\s*").map(_.nn)
     if (address.length > 1) Good(address.toList)
     else Bad(One(s"An address needs to have a street and a city, separated by a comma; found [$in]"))
   }

--- a/scalactic-test/src/test/scala/org/scalactic/CatcherSpec.scala
+++ b/scalactic-test/src/test/scala/org/scalactic/CatcherSpec.scala
@@ -33,7 +33,7 @@ class CatcherSpec extends UnitSpec {
   }
 
   it should "be usable as an extractor for catching exceptions" in {
-    val InternalServerError = Catcher { case dbae: DBAccessException => dbae.getMessage == "500: Internal Server Error" }
+    val InternalServerError = Catcher {((x : Throwable) => x match {case dbae: DBAccessException => dbae.getMessage == "500: Internal Server Error"}).asInstanceOf[PartialFunction[Throwable, Boolean]] }
     try throw new DBAccessException(msg500)
     catch {
       case InternalServerError(e) =>
@@ -52,7 +52,7 @@ class CatcherSpec extends UnitSpec {
   }
 
   it should "be usable as an extractor for detecting exceptions in Failed outcomes in withFixtures" in {
-    val InternalServerError = Catcher { case dbae: DBAccessException => dbae.getMessage == "500: Internal Server Error" }
+    val InternalServerError = Catcher {((x : Throwable) => x match {case dbae: DBAccessException => dbae.getMessage == "500: Internal Server Error"}).asInstanceOf[PartialFunction[Throwable, Boolean]] }
     val outcome1: Outcome = Failed(new DBAccessException(msg500))
     outcome1 match {
       case Failed(InternalServerError(e)) =>

--- a/scalactic-test/src/test/scala/org/scalactic/CatcherSpec.scala
+++ b/scalactic-test/src/test/scala/org/scalactic/CatcherSpec.scala
@@ -33,7 +33,7 @@ class CatcherSpec extends UnitSpec {
   }
 
   it should "be usable as an extractor for catching exceptions" in {
-    val InternalServerError = Catcher {((x : Throwable) => x match {case dbae: DBAccessException => dbae.getMessage == "500: Internal Server Error"}).asInstanceOf[PartialFunction[Throwable, Boolean]] }
+    val InternalServerError = Catcher {{case dbae: DBAccessException => dbae.getMessage == "500: Internal Server Error"}: PartialFunction[Throwable, Boolean] }
     try throw new DBAccessException(msg500)
     catch {
       case InternalServerError(e) =>
@@ -52,7 +52,7 @@ class CatcherSpec extends UnitSpec {
   }
 
   it should "be usable as an extractor for detecting exceptions in Failed outcomes in withFixtures" in {
-    val InternalServerError = Catcher {((x : Throwable) => x match {case dbae: DBAccessException => dbae.getMessage == "500: Internal Server Error"}).asInstanceOf[PartialFunction[Throwable, Boolean]] }
+    val InternalServerError = Catcher {{case dbae: DBAccessException => dbae.getMessage == "500: Internal Server Error"}: PartialFunction[Throwable, Boolean] }
     val outcome1: Outcome = Failed(new DBAccessException(msg500))
     outcome1 match {
       case Failed(InternalServerError(e)) =>

--- a/scalactic-test/src/test/scala/org/scalactic/DirectRequirementsSpec.scala
+++ b/scalactic-test/src/test/scala/org/scalactic/DirectRequirementsSpec.scala
@@ -4783,7 +4783,7 @@ class DirectRequirementsSpec extends FunSpec with OptionValues {
 
     it("should throw NullArgumentException with correct message when one of passed parameters through object property is null") {
       class AClass {
-        val aNull: String = null
+        val aNull: String | Null = null
       }
       val aClass = new AClass
       val e = intercept[NullArgumentException] {
@@ -4794,7 +4794,7 @@ class DirectRequirementsSpec extends FunSpec with OptionValues {
 
     it("should throw NullArgumentException with correct message when one of passed parameters through object method call is null") {
       class AClass {
-        def returnNull: String = null
+        def returnNull: String | Null = null
       }
       val aClass = new AClass
       val e = intercept[NullArgumentException] {
@@ -4804,7 +4804,7 @@ class DirectRequirementsSpec extends FunSpec with OptionValues {
     }
 
     it("should throw NullArgumentException with correct message when one of passed parameters through method call is null") {
-      def returnNull: String = null
+      def returnNull: String | Null = null
       val e = intercept[NullArgumentException] {
         org.scalactic.Requirements.requireNonNull(prefix, returnNull, suffix)
       }

--- a/scalactic-test/src/test/scala/org/scalactic/RequirementsSpec.scala
+++ b/scalactic-test/src/test/scala/org/scalactic/RequirementsSpec.scala
@@ -4783,7 +4783,7 @@ class RequirementsSpec extends FunSpec with Requirements with OptionValues {
 
     it("should throw NullArgumentException with correct message when one of passed parameters through object property is null") {
       class AClass {
-        val aNull: String = null
+        val aNull: String | Null = null
       }
       val aClass = new AClass
       val e = intercept[NullArgumentException] {
@@ -4794,7 +4794,7 @@ class RequirementsSpec extends FunSpec with Requirements with OptionValues {
 
     it("should throw NullArgumentException with correct message when one of passed parameters through object method call is null") {
       class AClass {
-        def returnNull: String = null
+        def returnNull: String | Null = null
       }
       val aClass = new AClass
       val e = intercept[NullArgumentException] {
@@ -4804,7 +4804,7 @@ class RequirementsSpec extends FunSpec with Requirements with OptionValues {
     }
 
     it("should throw NullArgumentException with correct message when one of passed parameters through method call is null") {
-      def returnNull: String = null
+      def returnNull: String | Null = null
       val e = intercept[NullArgumentException] {
         requireNonNull(prefix, returnNull, suffix)
       }

--- a/scalactic-test/src/test/scala/org/scalactic/TripleEqualsSpec.scala
+++ b/scalactic-test/src/test/scala/org/scalactic/TripleEqualsSpec.scala
@@ -32,7 +32,7 @@ class TripleEqualsSpec extends FunSpec with NonImplicitAssertions {
   val sub1: Sub = new Sub(1)
   val super2: Super = new Super(2)
   val sub2: Sub = new Sub(2)
-  val nullSuper: Super = null
+  val nullSuper: Super | Null = null
 
   describe("the custom equality === operator") {
 

--- a/scalactic-test/src/test/scala/org/scalactic/TypeCheckedMapEqualityConstraintsSpec.scala
+++ b/scalactic-test/src/test/scala/org/scalactic/TypeCheckedMapEqualityConstraintsSpec.scala
@@ -33,7 +33,7 @@ class TypeCheckedMapEqualityConstraintsSpec extends FunSpec with NonImplicitAsse
   val sub1: Sub = new Sub(1)
   val super2: Super = new Super(2)
   val sub2: Sub = new Sub(2)
-  val nullSuper: Super = null
+  val nullSuper: Super | Null = null
 
   case class Fruit(name: String)
   class Apple extends Fruit("apple")

--- a/scalactic-test/src/test/scala/org/scalactic/TypeCheckedSeqEqualityConstraintsSpec.scala
+++ b/scalactic-test/src/test/scala/org/scalactic/TypeCheckedSeqEqualityConstraintsSpec.scala
@@ -32,7 +32,7 @@ class TypeCheckedSeqEqualityConstraintsSpec extends FunSpec with NonImplicitAsse
   val sub1: Sub = new Sub(1)
   val super2: Super = new Super(2)
   val sub2: Sub = new Sub(2)
-  val nullSuper: Super = null
+  val nullSuper: Super | Null = null
 
   case class Fruit(name: String)
   class Apple extends Fruit("apple")

--- a/scalactic-test/src/test/scala/org/scalactic/TypeCheckedSetEqualityConstraintsSpec.scala
+++ b/scalactic-test/src/test/scala/org/scalactic/TypeCheckedSetEqualityConstraintsSpec.scala
@@ -33,7 +33,7 @@ class TypeCheckedSetEqualityConstraintsSpec extends FunSpec with NonImplicitAsse
   val sub1: Sub = new Sub(1)
   val super2: Super = new Super(2)
   val sub2: Sub = new Sub(2)
-  val nullSuper: Super = null
+  val nullSuper: Super | Null = null
 
   case class Fruit(name: String)
   class Apple extends Fruit("apple")

--- a/scalactic-test/src/test/scala/org/scalactic/TypeCheckedTraversableEqualityConstraintsSpec.scala
+++ b/scalactic-test/src/test/scala/org/scalactic/TypeCheckedTraversableEqualityConstraintsSpec.scala
@@ -33,7 +33,7 @@ class TypeCheckedTraversableEqualityConstraintsSpec extends FunSpec with NonImpl
   val sub1: Sub = new Sub(1)
   val super2: Super = new Super(2)
   val sub2: Sub = new Sub(2)
-  val nullSuper: Super = null
+  val nullSuper: Super | Null = null
 
   case class Fruit(name: String)
   class Apple extends Fruit("apple")

--- a/scalactic.dotty/src/main/scala/org/scalactic/anyvals/NumericString.scala
+++ b/scalactic.dotty/src/main/scala/org/scalactic/anyvals/NumericString.scala
@@ -541,7 +541,7 @@ final class NumericString private (val value: String) extends AnyVal {
    * @return         array of strings produced by splitting `NumericString` at every location matching supplied `regex`
    */
   def split(regex: String): Array[String] =
-    value.split(regex)
+    value.split(regex).map(_.nn)
 
   /**
    * Returns an array of strings produced by splitting `NumericString` at up to `limit` locations matching the supplied `regex`;
@@ -554,7 +554,7 @@ final class NumericString private (val value: String) extends AnyVal {
    * @return         array of strings produced by splitting `NumericString` at every location matching supplied `regex`, up to `limit` occurrences
    */
   def split(regex: String, limit: Int): Array[String] =
-    value.split(regex, limit)
+    value.split(regex, limit).map(_.nn)
 
   /**
    * Returns `true` if the `NumericString` content completely matches the supplied `prefix`, when both strings are aligned at their startpoints

--- a/scalactic.dotty/src/main/scala/org/scalactic/anyvals/RegexString.scala
+++ b/scalactic.dotty/src/main/scala/org/scalactic/anyvals/RegexString.scala
@@ -125,10 +125,10 @@ private[scalactic] final class RegexString private (val value: String) extends A
     value.replaceFirst(regex, replacement)
 
   def split(regex: String): Array[String] =
-    value.split(regex)
+    value.split(regex).map(_.nn)
 
   def split(regex: String, limit: Int): Array[String] =
-    value.split(regex, limit)
+    value.split(regex, limit).map(_.nn)
 
   def startsWith(prefix: String): Boolean =
     value.startsWith(prefix)

--- a/scalactic/src/main/scala/org/scalactic/Catcher.scala
+++ b/scalactic/src/main/scala/org/scalactic/Catcher.scala
@@ -98,7 +98,7 @@ val InternalServerError =
  *
  * @param partial the partial function that is used by this extractor to determine matches
  */
-class Catcher(partial: PartialFunction[Throwable, Boolean]) {
+class Catcher(partial: PartialFunction[Throwable, Boolean] | Null) {
   if (partial == null) throw new NullPointerException("partial was null")
 
   /**
@@ -108,7 +108,7 @@ class Catcher(partial: PartialFunction[Throwable, Boolean]) {
    * @param exception the exception on which to match
    */
   def unapply(exception: Throwable): Option[Throwable] = {
-    if (partial.isDefinedAt(exception) && partial(exception)) Some(exception) else None
+    if (partial.nn.isDefinedAt(exception) && partial.nn(exception)) Some(exception) else None
   }
 }
 
@@ -122,6 +122,6 @@ object Catcher {
    *
    * @param partial the partial function that is used by returned extractor to determine matches
    */
-  def apply(partial: PartialFunction[Throwable, Boolean]): Catcher = new Catcher(partial)
+  def apply(partial: PartialFunction[Throwable, Boolean] | Null): Catcher = new Catcher(partial)
 }
 

--- a/scalactic/src/main/scala/org/scalactic/source/ObjectMeta.scala
+++ b/scalactic/src/main/scala/org/scalactic/source/ObjectMeta.scala
@@ -33,10 +33,10 @@ object ObjectMeta {
 
   def objectMetaUsingJavaReflection(v: Any): ObjectMeta =
     new ObjectMeta {
-      lazy val privFields = v.getClass.getDeclaredFields.filter(!_.isAccessible).map(_.getName)
+      lazy val privFields = v.getClass.getDeclaredFields.map(_.nn).filter(!_.isAccessible).map(_.getName)
 
       lazy val fieldNames = {
-        v.getClass.getDeclaredMethods.filter { m =>
+        v.getClass.getDeclaredMethods.map(_.nn).filter { m =>
           // SKIP-DOTTY-START
           m.getParameterTypes.isEmpty && privFields.contains(m.getName)
           // SKIP-DOTTY-END

--- a/scalatest-test/src/test/scala/org/scalatest/AssertionsSpec.scala
+++ b/scalatest-test/src/test/scala/org/scalatest/AssertionsSpec.scala
@@ -71,8 +71,8 @@ class AssertionsSpec extends AnyFunSpec {
       }
     }
     it("should compare nulls in a satisfying manner") {
-      val n1: String = null
-      val n2: String = null
+      val n1: String | Null = null
+      val n2: String | Null = null
       assert(n1 === n2)
       intercept[TestFailedException] {
         assert(n1 === "hi")
@@ -6599,8 +6599,8 @@ class AssertionsSpec extends AnyFunSpec {
       }
     }
     it("should compare nulls in a satisfying manner") {
-      val n1: String = null
-      val n2: String = null
+      val n1: String | Null = null
+      val n2: String | Null = null
       assertResult(n1) { n2 }
       intercept[TestFailedException] {
         assertResult(n1) { "hi" }
@@ -6668,8 +6668,8 @@ class AssertionsSpec extends AnyFunSpec {
       }
     }
     it("should compare nulls in a satisfying manner") {
-      val n1: String = null
-      val n2: String = null
+      val n1: String | Null = null
+      val n2: String | Null = null
       assertResult(n1, "a clue") { n2 }
       intercept[TestFailedException] {
         assertResult(n1, "a clue") { "hi" }

--- a/scalatest/src/main/scala/org/scalatest/AsyncEngine.scala
+++ b/scalatest/src/main/scala/org/scalatest/AsyncEngine.scala
@@ -850,7 +850,7 @@ private[scalatest] sealed abstract class AsyncSuperEngine[T](concurrentBundleMod
   private[scalatest] def testTags(testName: String, theSuite: Suite): Set[String] = {
     // SKIP-SCALATESTJS,NATIVE-START
     val suiteTags = for { 
-      a: Annotation <- theSuite.getClass.getAnnotations
+      a <- theSuite.getClass.getAnnotations.map(_.nn)
       annotationClass = a.annotationType
       if annotationClass.isAnnotationPresent(classOf[TagAnnotation])
     } yield annotationClass.getName

--- a/scalatest/src/main/scala/org/scalatest/AsyncEngine.scala
+++ b/scalatest/src/main/scala/org/scalatest/AsyncEngine.scala
@@ -850,7 +850,7 @@ private[scalatest] sealed abstract class AsyncSuperEngine[T](concurrentBundleMod
   private[scalatest] def testTags(testName: String, theSuite: Suite): Set[String] = {
     // SKIP-SCALATESTJS,NATIVE-START
     val suiteTags = for { 
-      a <- theSuite.getClass.getAnnotations
+      a: Annotation <- theSuite.getClass.getAnnotations
       annotationClass = a.annotationType
       if annotationClass.isAnnotationPresent(classOf[TagAnnotation])
     } yield annotationClass.getName

--- a/scalatest/src/main/scala/org/scalatest/Engine.scala
+++ b/scalatest/src/main/scala/org/scalatest/Engine.scala
@@ -597,7 +597,7 @@ private[scalatest] sealed abstract class SuperEngine[T](concurrentBundleModMessa
           pos match {
             case Some(pos) => Some(LineInFile(pos.lineNumber, pos.fileName, Some(pos.filePathname)))
             case None =>
-              val stackTraceElements = Thread.currentThread().getStackTrace
+              val stackTraceElements = Thread.currentThread().getStackTrace.map(_.nn)
               getLineInFile(stackTraceElements, stackDepth)
           }
       }
@@ -639,7 +639,7 @@ private[scalatest] sealed abstract class SuperEngine[T](concurrentBundleModMessa
       pos match {
         case Some(pos) => Some(LineInFile(pos.lineNumber, pos.fileName, Some(pos.filePathname)))
         case None =>
-          val stackTraceElements = Thread.currentThread().getStackTrace
+          val stackTraceElements = Thread.currentThread().getStackTrace.map(_.nn)
           getLineInFile(stackTraceElements, stackDepth)
       }
     val newBranch = DescriptionBranch(Trunk, description, None, lineInFile)
@@ -684,7 +684,7 @@ private[scalatest] sealed abstract class SuperEngine[T](concurrentBundleModMessa
           pos match {
             case Some(pos) => Some(LineInFile(pos.lineNumber, pos.fileName, Some(pos.filePathname)))
             case None =>
-              val stackTraceElements = Thread.currentThread().getStackTrace
+              val stackTraceElements = Thread.currentThread().getStackTrace.map(_.nn)
               getLineInFile(stackTraceElements, stackDepth)
           }
       }
@@ -781,7 +781,7 @@ private[scalatest] sealed abstract class SuperEngine[T](concurrentBundleModMessa
   private[scalatest] def testTags(testName: String, theSuite: Suite): Set[String] = {
     // SKIP-SCALATESTJS,NATIVE-START
     val suiteTags = for { 
-      a <- theSuite.getClass.getAnnotations
+      a <- theSuite.getClass.getAnnotations.map(_.nn)
       annotationClass = a.annotationType
       if annotationClass.isAnnotationPresent(classOf[TagAnnotation])
     } yield annotationClass.getName
@@ -857,7 +857,7 @@ private[scalatest] class PathEngine(concurrentBundleModMessageFun: => String, si
   // Used in each instance to track the paths of things encountered, so can figure out
   // the next path. Each instance must use their own copies of currentPath and usedPathSet.
   def getNextPath() = {
-    var next: List[Int] = null
+    var next: List[Int] | Null = null
     var count = 0
     while (next == null) {
       val candidate = currentPath ::: List(count)
@@ -868,7 +868,7 @@ private[scalatest] class PathEngine(concurrentBundleModMessageFun: => String, si
       else
         count += 1
     }
-    next
+    next.nn
   }
 
   /*

--- a/scalatest/src/main/scala/org/scalatest/Entry.scala
+++ b/scalatest/src/main/scala/org/scalatest/Entry.scala
@@ -39,7 +39,7 @@ package org.scalatest
  * @param value the value of this entry
  */
 // SKIP-SCALATESTJS,NATIVE-START
-case class Entry[K, V](key: K, value: V) extends java.util.Map.Entry[K, V] {
+case class Entry[K, V](key: K | Null, value: V | Null) extends java.util.Map.Entry[K, V] {
 // SKIP-SCALATESTJS,NATIVE-END
 //SCALATESTJS,NATIVE-ONLY case class Entry[K, V](key: K, value: V) {
 
@@ -48,21 +48,21 @@ case class Entry[K, V](key: K, value: V) extends java.util.Map.Entry[K, V] {
    *
    * @return the key corresponding to this entry
    */
-  def getKey: K = key
+  def getKey: K = key.asInstanceOf[K]
 
   /**
    * Returns the value corresponding to this entry.
    *
    * @return the value corresponding to this entry 
    */
-  def getValue: V = value
+  def getValue: V = value.asInstanceOf[V]
 
   /**
    * Throws <code>UnsupportedOperationException</code>.
    *
    * @throws UnsupportedOperationException unconditionally
    */
-  def setValue(v: V): V = throw new UnsupportedOperationException
+  def setValue(v: V | Null): V = throw new UnsupportedOperationException
 
   /**
    * Compares the specified object with this entry for equality.

--- a/scalatest/src/main/scala/org/scalatest/InsertionOrderSet.scala
+++ b/scalatest/src/main/scala/org/scalatest/InsertionOrderSet.scala
@@ -17,7 +17,7 @@ package org.scalatest
 
 private[scalatest] object InsertionOrderSet {
   def apply[A](elements: List[A]): Set[A] =
-    scala.collection.immutable.SortedSet(elements: _*)(new Ordering[A] {
-      def compare(x: A, y: A): Int = elements.indexOf(x) compare elements.indexOf(y)
-    })
+    scala.collection.immutable.SortedSet(elements: _*)(new Ordering[A | Null] {
+      def compare(x: A | Null, y: A | Null): Int = elements.indexOf(x) compare elements.indexOf(y)
+    }).asInstanceOf[Set[A]]
 }

--- a/scalatest/src/main/scala/org/scalatest/PrivateMethodTester.scala
+++ b/scalatest/src/main/scala/org/scalatest/PrivateMethodTester.scala
@@ -166,7 +166,7 @@ trait PrivateMethodTester {
 
         val isInstanceMethod = !Modifier.isStatic(m.getModifiers())
         val simpleName = m.getName
-        val paramTypes = m.getParameterTypes
+        val paramTypes: Seq[Class[_]] = m.getParameterTypes.map(_.nn)
         val isPrivate = Modifier.isPrivate(m.getModifiers())
 
         // The AnyVals must go in as Java wrapper types. But the type is still Any, so this needs to be converted
@@ -240,7 +240,7 @@ trait PrivateMethodTester {
       // Store in an array, because may have both isEmpty and empty, in which case I
       // will throw an exception.
       val methodArray =
-        for (m <- target.getClass.getDeclaredMethods; if isMethodToInvoke(m))
+        for (m <- target.getClass.getDeclaredMethods.map(_.nn); if isMethodToInvoke(m))
           yield m
   
       if (methodArray.length == 0)

--- a/scalatest/src/main/scala/org/scalatest/Shell.scala
+++ b/scalatest/src/main/scala/org/scalatest/Shell.scala
@@ -377,7 +377,7 @@ sealed trait Shell {
    * this method is invoked.
    * </p>
    */
-  def run(suite: Suite, testName: String = null, configMap: ConfigMap = ConfigMap.empty): Unit
+  def run(suite: Suite, testName: String | Null = null, configMap: ConfigMap = ConfigMap.empty): Unit
 }
 
 // parameters were private, but after pulling out the trait so I don't import copy() as part
@@ -401,7 +401,7 @@ private[scalatest] final case class ShellImpl(
   lazy val nostacks: Shell = copy(shortstacksPassed = false, fullstacksPassed = false)
   lazy val nostats: Shell = copy(statsPassed = false)
 
-  def run(suite: Suite, testName: String = null, configMap: ConfigMap = ConfigMap.empty): Unit = {
+  def run(suite: Suite, testName: String | Null = null, configMap: ConfigMap = ConfigMap.empty): Unit = {
     suite.execute(testName, configMap, colorPassed, durationsPassed, shortstacksPassed, fullstacksPassed, statsPassed)
   }
 }

--- a/scalatest/src/main/scala/org/scalatest/Suite.scala
+++ b/scalatest/src/main/scala/org/scalatest/Suite.scala
@@ -756,7 +756,7 @@ trait Suite extends Assertions with Serializable { thisSuite =>
    *     exists in this <code>Suite</code>
    */
   final def execute(
-    testName: String = null,
+    testName: String | Null = null,
     configMap: ConfigMap = ConfigMap.empty,
     color: Boolean = true,
     durations: Boolean = false,
@@ -2010,7 +2010,7 @@ used for test events like succeeded/failed, etc.
   def autoTagClassAnnotations(tags: Map[String, Set[String]], theSuite: Suite) = {
     // SKIP-SCALATESTJS,NATIVE-START
     val suiteTags = for {
-      a <- theSuite.getClass.getAnnotations
+      a <- theSuite.getClass.getAnnotations.map(_.nn)
       annotationClass = a.annotationType
       if annotationClass.isAnnotationPresent(classOf[TagAnnotation])
     } yield annotationClass.getName
@@ -2088,7 +2088,7 @@ used for test events like succeeded/failed, etc.
 
   // SKIP-SCALATESTJS,NATIVE-START
   def getMethodForTestName(theSuite: org.scalatest.Suite, testName: String): Method = {
-    val candidateMethods = theSuite.getClass.getMethods.filter(_.getName == Suite.simpleNameForTest(testName))
+    val candidateMethods = theSuite.getClass.getMethods.map(_.nn).filter(_.getName == Suite.simpleNameForTest(testName))
     val found =
       if (testMethodTakesAFixtureAndInformer(testName))
         candidateMethods.find(
@@ -2153,7 +2153,7 @@ used for test events like succeeded/failed, etc.
     }
 
     val testNameArray =
-      for (m <- theSuite.getClass.getMethods; if isTestMethod(m))
+      for (m <- theSuite.getClass.getMethods.map(_.nn); if isTestMethod(m))
         yield if (takesInformer(m)) m.getName + InformerInParens else m.getName
 
     val result = TreeSet.empty[String](EncodedOrdering) ++ testNameArray

--- a/scalatest/src/main/scala/org/scalatest/concurrent/PimpedThreadGroup.scala
+++ b/scalatest/src/main/scala/org/scalatest/concurrent/PimpedThreadGroup.scala
@@ -74,7 +74,7 @@ private[concurrent] class PimpedThreadGroup(threadGroup: ThreadGroup) {
   def getThreads(recursive: Boolean): List[Thread] = {
     def getThreads(sizeEstimate: Int): Seq[Thread] = {
       val ths = new Array[Thread](sizeEstimate)
-      if (threadGroup.enumerate(ths, recursive) == sizeEstimate) getThreads(sizeEstimate + 10)
+      if (threadGroup.enumerate(ths.asInstanceOf[Array[Thread | Null]], recursive) == sizeEstimate) getThreads(sizeEstimate + 10)
       else for (t <- ths; if (t != null)) yield t
     }
     getThreads(threadGroup.activeCount() + 10).toList

--- a/scalatest/src/main/scala/org/scalatest/enablers/Retrying.scala
+++ b/scalatest/src/main/scala/org/scalatest/enablers/Retrying.scala
@@ -59,7 +59,7 @@ object Retrying {
   private lazy val scheduler: ScheduledExecutorService = {
     val threadFactory = new ThreadFactory {
       val inner = Executors.defaultThreadFactory()
-      def newThread(runnable: Runnable) = {
+      def newThread(runnable: Runnable | Null) = {
         val thread = inner.newThread(runnable)
         thread.setDaemon(true)
         thread

--- a/scalatest/src/main/scala/org/scalatest/events/Event.scala
+++ b/scalatest/src/main/scala/org/scalatest/events/Event.scala
@@ -151,7 +151,7 @@ sealed abstract class Event extends Ordered[Event] with Product with Serializabl
           <depth>{ getThrowableStackDepth(throwable) }</depth>
           <stackTraces>
             {
-              val stackTraces = throwable.getStackTrace
+              val stackTraces = throwable.getStackTrace.map(_.nn)
               for (stackTrace <- stackTraces) yield {
                 <stackTrace>
                   <className>{ stackTrace.getClassName }</className>
@@ -250,8 +250,10 @@ sealed abstract class Event extends Ordered[Event] with Product with Serializabl
       }
     }
 
-    def stackTrace(st: StackTraceElement): String =
+    def stackTrace(_st: StackTraceElement | Null): String = {
+      val st = _st.nn
       s"""{ "className": ${stringOption(Option(st.getClassName))}, "methodName": ${stringOption(Option(st.getMethodName))}, "fileName": ${stringOption(Option(st.getFileName))}, "lineNumber": ${st.getLineNumber}, "isNative": ${st.isNativeMethod}, "toString": ${stringOption(Option(st.toString))} }"""
+    }
 
     def throwableOption(throwableOption: Option[Throwable]) = {
       throwableOption match {

--- a/scalatest/src/main/scala/org/scalatest/exceptions/StackDepth.scala
+++ b/scalatest/src/main/scala/org/scalatest/exceptions/StackDepth.scala
@@ -90,7 +90,7 @@ trait StackDepth { this: Throwable =>
   }
 
   private def stackTraceElement: Option[StackTraceElement] = {
-    val stackTrace = getStackTrace()
+    val stackTrace = getStackTrace().map(_.nn)
     position match {
       case Some(pos) => stackTrace.find(e => StackDepthExceptionHelper.isMatch(e, pos))
       case None =>

--- a/scalatest/src/main/scala/org/scalatest/exceptions/StackDepthException.scala
+++ b/scalatest/src/main/scala/org/scalatest/exceptions/StackDepthException.scala
@@ -184,13 +184,13 @@ abstract class StackDepthException(
    *
    * @return the detail message string of this <code>StackDepthException</code> instance (which may be <code>null</code>).
    */
-  override def getMessage: String | Null = message.orNull
+  override def getMessage= message.orNull.asInstanceOf[String]
 
   /*
   * Throws <code>IllegalStateException</code>, because <code>StackDepthException</code>s are
   * always initialized with a cause passed to the constructor of superclass <code>RuntimeException</code>.
   */
-  override final def initCause(throwable: Throwable): Throwable = { throw new IllegalStateException }
+  override final def initCause(throwable: Throwable | Null): Throwable = { throw new IllegalStateException }
 
   /**
    * Indicates whether this object can be equal to the passed object.

--- a/scalatest/src/main/scala/org/scalatest/exceptions/StackDepthException.scala
+++ b/scalatest/src/main/scala/org/scalatest/exceptions/StackDepthException.scala
@@ -184,7 +184,7 @@ abstract class StackDepthException(
    *
    * @return the detail message string of this <code>StackDepthException</code> instance (which may be <code>null</code>).
    */
-  override def getMessage: String = message.orNull
+  override def getMessage: String | Null = message.orNull
 
   /*
   * Throws <code>IllegalStateException</code>, because <code>StackDepthException</code>s are

--- a/scalatest/src/main/scala/org/scalatest/exceptions/StackDepthExceptionHelper.scala
+++ b/scalatest/src/main/scala/org/scalatest/exceptions/StackDepthExceptionHelper.scala
@@ -140,7 +140,7 @@ private[scalatest] object StackDepthExceptionHelper extends Serializable {
   }
 
   def getStackDepthFun(fileName: String, methodName: String, adjustment: Int = 0): (StackDepthException => Int) = { sde =>
-    getStackDepth(sde.getStackTrace, fileName, methodName, adjustment)
+    getStackDepth(sde.getStackTrace.map(_.nn), fileName, methodName, adjustment)
   }
 
   def isMatch(ele: StackTraceElement, pos: source.Position): Boolean =
@@ -152,7 +152,7 @@ private[scalatest] object StackDepthExceptionHelper extends Serializable {
   }
 
   def getStackDepthFun(pos: source.Position): (StackDepthException => Int) = { sde =>
-    getStackDepth(sde.getStackTrace, pos)
+    getStackDepth(sde.getStackTrace.map(_.nn), pos)
   }
 
   def getFailedCodeFileName(stackTraceElement: StackTraceElement): Option[String] = {

--- a/scalatest/src/main/scala/org/scalatest/matchers/MatchersHelper.scala
+++ b/scalatest/src/main/scala/org/scalatest/matchers/MatchersHelper.scala
@@ -67,22 +67,26 @@ private[scalatest] object MatchersHelper {
     val methodNameStartsWithVowel = firstChar == 'a' || firstChar == 'e' || firstChar == 'i' ||
       firstChar == 'o' || firstChar == 'u'
 
-    def isFieldToAccess(field: Field): Boolean = field.getName == fieldNameToAccess
+    def isFieldToAccess(field: Field | Null): Boolean = field.nn.getName == fieldNameToAccess
 
     // If it is a predicate, I check the result type, otherwise I don't. Maybe I should just do that. Could be a later enhancement.
-    def isMethodToInvoke(method: Method): Boolean =
+    def isMethodToInvoke(_method: Method | Null): Boolean = {
+      val method = _method.nn
       method.getName == methodNameToInvoke && method.getParameterTypes.length == 0 && !Modifier.isStatic(method.getModifiers()) &&
         (!isBooleanProperty || method.getReturnType == classOf[Boolean])
+    }
 
-    def isGetMethodToInvoke(method: Method): Boolean =
+    def isGetMethodToInvoke(_method: Method | Null): Boolean = {
+      val method = _method.nn
       method.getName == methodNameToInvokeWithGet && method.getParameterTypes.length == 0 && !Modifier.isStatic(method.getModifiers()) &&
         (!isBooleanProperty || method.getReturnType == classOf[Boolean])
+    }
 
-    val fieldOption = objectWithProperty.getClass.getFields.find(isFieldToAccess)
+    val fieldOption = objectWithProperty.getClass.getFields.map(_.nn).find(isFieldToAccess)
 
-    val methodOption = objectWithProperty.getClass.getMethods.find(isMethodToInvoke)
+    val methodOption = objectWithProperty.getClass.getMethods.map(_.nn).find(isMethodToInvoke)
 
-    val getMethodOption = objectWithProperty.getClass.getMethods.find(isGetMethodToInvoke)
+    val getMethodOption = objectWithProperty.getClass.getMethods.map(_.nn).find(isGetMethodToInvoke)
 
     (fieldOption, methodOption, getMethodOption) match {
 

--- a/scalatest/src/main/scala/org/scalatest/matchers/WillMatchersHelper.scala
+++ b/scalatest/src/main/scala/org/scalatest/matchers/WillMatchersHelper.scala
@@ -68,6 +68,6 @@ private[scalatest] object WillMatchersHelper {
     )(prettifier)
 
   def indicateFailure(e: TestFailedException)(implicit prettifier: Prettifier): Fact =
-    Fact.No(e.getMessage)(prettifier)
+    Fact.No(e.getMessage.nn)(prettifier)
 
 }

--- a/scalatest/src/main/scala/org/scalatest/matchers/should/Matchers.scala
+++ b/scalatest/src/main/scala/org/scalatest/matchers/should/Matchers.scala
@@ -5835,7 +5835,7 @@ org.scalatest.exceptions.TestFailedException: org.scalatest.Matchers$ResultOfCol
         }
         catch {
           case tfe: TestFailedException =>
-            indicateFailure(tfe.getMessage, tfe.cause, pos)
+            indicateFailure(tfe.getMessage.nn, tfe.cause, pos)
         }
       }
     }

--- a/scalatest/src/main/scala/org/scalatest/refspec/RefSpecLike.scala
+++ b/scalatest/src/main/scala/org/scalatest/refspec/RefSpecLike.scala
@@ -65,7 +65,7 @@ trait RefSpecLike extends TestSuite with Informing with Notifying with Alerting 
         
         def getMethodTags(o: AnyRef, methodName: String) =
           for {
-            a <- getMethod(o, methodName).getDeclaredAnnotations
+            a <- getMethod(o, methodName).getDeclaredAnnotations.map(_.nn)
             annotationClass = a.annotationType
             if annotationClass.isAnnotationPresent(classOf[TagAnnotation])
           } yield annotationClass.getName
@@ -100,7 +100,7 @@ trait RefSpecLike extends TestSuite with Informing with Notifying with Alerting 
         }
         
         def register(o: AnyRef): Unit = {
-          val testMethods = o.getClass.getMethods.filter(isTestMethod(_)).sorted(MethodNameEncodedOrdering)
+          val testMethods = o.getClass.getMethods.map(_.nn).filter(isTestMethod(_)).sorted(MethodNameEncodedOrdering)
           
           testMethods.foreach { m =>
             val scope = isScopeMethod(o, m)

--- a/scalatest/src/main/scala/org/scalatest/run.scala
+++ b/scalatest/src/main/scala/org/scalatest/run.scala
@@ -130,7 +130,7 @@ object run {
    * <code>fullStacksPassed</code>, and <code>statsPassed</code>).
    * </p>
    */
-  def apply(suite: Suite, testName: String = null, configMap: ConfigMap = ConfigMap.empty): Unit = {
+  def apply(suite: Suite, testName: String | Null = null, configMap: ConfigMap = ConfigMap.empty): Unit = {
     defaultShell.run(suite, testName, configMap)
   }
 }

--- a/scalatest/src/main/scala/org/scalatest/tools/ColorBar.scala
+++ b/scalatest/src/main/scala/org/scalatest/tools/ColorBar.scala
@@ -82,11 +82,12 @@ private[scalatest] class ColorBar extends JPanel {
     repaint()
   }
 
-  override def update(g: Graphics): Unit = {
+  override def update(g: Graphics | Null): Unit = {
     paint(g)
   }
 
-  override def paint(g: Graphics): Unit = {
+  override def paint(_g: Graphics | Null): Unit = {
+    val g = _g.nn
 
     val dim: Dimension = getSize()
 

--- a/scalatest/src/main/scala/org/scalatest/tools/DiscoverySuite.scala
+++ b/scalatest/src/main/scala/org/scalatest/tools/DiscoverySuite.scala
@@ -16,6 +16,7 @@
 package org.scalatest.tools
 
 import org.scalatest._
+import java.lang.reflect.Constructor
 import java.util.UUID
 import org.scalactic.Requirements._
 
@@ -66,7 +67,7 @@ private[scalatest] object DiscoverySuite {
         clazz.newInstance.asInstanceOf[Suite]
       else {
         val suiteClazz = wrapWithAnnotation.value
-        val constructorList = suiteClazz.getDeclaredConstructors()
+        val constructorList : Array[Constructor[_]] = suiteClazz.getDeclaredConstructors().map(_.nn)
         val constructor = constructorList.find { c => 
           val types = c.getParameterTypes
           types.length == 1 && types(0) == classOf[java.lang.Class[_]]

--- a/scalatest/src/main/scala/org/scalatest/tools/Fragment.scala
+++ b/scalatest/src/main/scala/org/scalatest/tools/Fragment.scala
@@ -25,7 +25,7 @@ private[scalatest] case class Fragment(text: String, ansiColor: AnsiColor) {
     if (!presentInColor || text.trim.isEmpty) text
     else {
       ("\n" * countLeadingEOLs(text)) +
-      text.split("\n").dropWhile(_.isEmpty).map(ansiColor.code + _ + ansiReset).mkString("\n") +
+      text.split("\n").map(_.nn).dropWhile(_.isEmpty).map(ansiColor.code + _ + ansiReset).mkString("\n") +
       ("\n" * countTrailingEOLs(text))
     }
 }

--- a/scalatest/src/main/scala/org/scalatest/tools/Framework.scala
+++ b/scalatest/src/main/scala/org/scalatest/tools/Framework.scala
@@ -22,6 +22,7 @@ import SuiteDiscoveryHelper._
 
 import scala.collection.JavaConverters._
 import java.io.{PrintWriter, StringWriter}
+import java.lang.reflect.Constructor
 import java.util.concurrent.atomic.{AtomicBoolean, AtomicInteger, AtomicReference}
 import java.util.concurrent.{ExecutorService, Executors, LinkedBlockingQueue, ThreadFactory}
 
@@ -417,7 +418,7 @@ class Framework extends SbtFramework {
     
     def tags = 
       for { 
-        a <- suiteClass.getAnnotations
+        a <- suiteClass.getAnnotations.map(_.nn)
         annotationClass = a.annotationType
         if (annotationClass.isAnnotationPresent(classOf[TagAnnotation]) || annotationClass.isAssignableFrom(classOf[TagAnnotation])) 
       } yield {
@@ -439,7 +440,7 @@ class Framework extends SbtFramework {
             if (runnable) { // When it is runnable WrapWith is available, this will take precedence and this behavior will be consistent with Runner and the old ScalaTestFramework.
               val wrapWithAnnotation = suiteClass.getAnnotation(classOf[WrapWith])
               val suiteClazz = wrapWithAnnotation.value
-              val constructorList = suiteClazz.getDeclaredConstructors()
+              val constructorList : Array[Constructor[_]] = suiteClazz.getDeclaredConstructors().map(_.nn)
               val constructor = constructorList.find { c =>
                 val types = c.getParameterTypes
                 types.length == 1 && types(0) == classOf[java.lang.Class[_]]
@@ -708,7 +709,7 @@ class Framework extends SbtFramework {
           tracker,
           tagsToInclude,
           tagsToExclude,
-          td.selectors ++ autoSelectors,
+          (td.selectors ++ autoSelectors).map(_.nn),
           td.explicitlySpecified, 
           configMap,
           summaryCounter,

--- a/scalatest/src/main/scala/org/scalatest/tools/HtmlReporter.scala
+++ b/scalatest/src/main/scala/org/scalatest/tools/HtmlReporter.scala
@@ -781,7 +781,7 @@ private[scalatest] class HtmlReporter(
     
     def displayErrorMessage(errorMessage: String) = {
       // scala automatically change <br /> to <br></br>, which will cause 2 line breaks, use unparsedXml("<br />") to solve it.
-      val messageLines = errorMessage.split("\n")
+      val messageLines = errorMessage.split("\n").map(_.nn)
       if (messageLines.size > 1)
         messageLines.map(line => <span>{ xmlContent(line) }{ unparsedXml("<br />") }</span>)
       else
@@ -810,7 +810,7 @@ private[scalatest] class HtmlReporter(
         </table>
         <table>
           <tr valign="top">
-            <td align="left" colspan="2">{ getHTMLForStackTrace(cause.getStackTrace.toList) }</td>
+            <td align="left" colspan="2">{ getHTMLForStackTrace(cause.getStackTrace.map(_.nn).toList) }</td>
           </tr>
         </table> &+ getHTMLForCause(cause)
       }
@@ -820,7 +820,7 @@ private[scalatest] class HtmlReporter(
     val (grayStackTraceElements, blackStackTraceElements) =
       throwable match {
         case Some(throwable) =>
-          val stackTraceElements = throwable.getStackTrace.toList
+          val stackTraceElements = throwable.getStackTrace.map(_.nn).toList
           throwable match {
             case sde: exceptions.StackDepthException =>
               (stackTraceElements.take(sde.failedCodeStackDepth), stackTraceElements.drop(sde.failedCodeStackDepth))

--- a/scalatest/src/main/scala/org/scalatest/tools/Memento.scala
+++ b/scalatest/src/main/scala/org/scalatest/tools/Memento.scala
@@ -136,7 +136,7 @@ private[tools] object Memento {
   // Constructs a Memento object from a single-line string.
   //
   def fromString(str: String): Memento = {
-    val splits = str.split(" ")
+    val splits = str.split(" ").map(_.nn)
 
     if (splits.length != 4)
       throw new Exception("bad line format ["+ str +"]")

--- a/scalatest/src/main/scala/org/scalatest/tools/Runner.scala
+++ b/scalatest/src/main/scala/org/scalatest/tools/Runner.scala
@@ -21,6 +21,7 @@ import java.net.MalformedURLException
 import java.net.URLClassLoader
 import java.io.File
 import java.io.IOException
+import java.lang.reflect.Constructor
 import javax.swing.SwingUtilities
 import java.util.concurrent.ArrayBlockingQueue
 import java.util.regex.Pattern
@@ -1447,7 +1448,7 @@ object Runner {
         clazz.newInstance.asInstanceOf[Suite]
       else {
         val suiteClazz = wrapWithAnnotation.value
-        val constructorList = suiteClazz.getDeclaredConstructors()
+        val constructorList : Array[Constructor[_]] = suiteClazz.getDeclaredConstructors().map(_.nn)
         val constructor = constructorList.find { c => 
           val types = c.getParameterTypes
           types.length == 1 && types(0) == classOf[java.lang.Class[_]]
@@ -1580,7 +1581,7 @@ object Runner {
         }
       }
 
-      new URLClassLoader(urlsList.toArray, classOf[Suite].getClassLoader)
+      new URLClassLoader(urlsList.toArray.asInstanceOf[Array[URL | Null]], classOf[Suite].getClassLoader)
     }
   }
 

--- a/scalatest/src/main/scala/org/scalatest/tools/Runner.scala
+++ b/scalatest/src/main/scala/org/scalatest/tools/Runner.scala
@@ -1318,7 +1318,7 @@ object Runner {
             val threadFactory =
               new ThreadFactory {
                 val defaultThreadFactory = Executors.defaultThreadFactory
-                def newThread(runnable: Runnable): Thread = {
+                def newThread(runnable: Runnable | Null): Thread = {
                   val thread = defaultThreadFactory.newThread(runnable)
                   thread.setName("ScalaTest-" + atomicThreadCounter.incrementAndGet())
                   thread

--- a/scalatest/src/main/scala/org/scalatest/tools/RunnerJFrame.scala
+++ b/scalatest/src/main/scala/org/scalatest/tools/RunnerJFrame.scala
@@ -186,7 +186,7 @@ private[scalatest] class RunnerJFrame(
     runJButton.setMnemonic(KeyEvent.VK_R)
     runJButton.addActionListener(
       new ActionListener() {
-        def actionPerformed(ae: ActionEvent): Unit = {
+        def actionPerformed(ae: ActionEvent | Null): Unit = {
           currentState = currentState.runButtonPressed(RunnerJFrame.this)
         }
       }
@@ -269,7 +269,7 @@ private[scalatest] class RunnerJFrame(
     reporterJPanel.add(eventsDetailsPanel, BorderLayout.CENTER)
     eventsJList.addListSelectionListener(
       new ListSelectionListener() {
-        def valueChanged(e: ListSelectionEvent): Unit = {
+        def valueChanged(e: ListSelectionEvent | Null): Unit = {
 
           val holder: EventHolder = eventsJList.getSelectedValue().asInstanceOf[EventHolder]
 
@@ -579,7 +579,7 @@ private[scalatest] class RunnerJFrame(
 
     rerunJButton.addActionListener(
       new ActionListener() {
-        def actionPerformed(ae: ActionEvent): Unit = {
+        def actionPerformed(ae: ActionEvent | Null): Unit = {
           currentState = currentState.rerunButtonPressed(RunnerJFrame.this)
         }
       }
@@ -611,7 +611,7 @@ private[scalatest] class RunnerJFrame(
     exitSemaphore.acquire()
     addWindowListener(
       new WindowAdapter {
-        override def windowClosed(e: WindowEvent): Unit = { exitSemaphore.release() }
+        override def windowClosed(e: WindowEvent | Null): Unit = { exitSemaphore.release() }
       }
     )
 
@@ -648,7 +648,7 @@ private[scalatest] class RunnerJFrame(
     scalaTestMenu.add(aboutItem)
     aboutItem.addActionListener(
       new ActionListener() {
-        def actionPerformed(ae: ActionEvent): Unit = {
+        def actionPerformed(ae: ActionEvent | Null): Unit = {
           val location: Point = getLocation()
           location.x += 20
           location.y += 6
@@ -665,7 +665,7 @@ private[scalatest] class RunnerJFrame(
     scalaTestMenu.add(exitItem)
     exitItem.addActionListener(
       new ActionListener() {
-        def actionPerformed(ae: ActionEvent): Unit = {
+        def actionPerformed(ae: ActionEvent | Null): Unit = {
           dispose()
           // Only exit if started from main(), not run(). If starting from run(),
           // we want to return a pass/fail status from run(). Actually, if we
@@ -689,7 +689,7 @@ private[scalatest] class RunnerJFrame(
     viewMenu.add(runsFailuresItem)
     runsFailuresItem.addActionListener(
       new ActionListener() {
-        def actionPerformed(ae: ActionEvent): Unit = {
+        def actionPerformed(ae: ActionEvent | Null): Unit = {
           viewOptions = runsAndFailures intersect eventTypesToCollect
           updateViewOptionsAndEventsList()
         }
@@ -701,7 +701,7 @@ private[scalatest] class RunnerJFrame(
     viewMenu.add(allEventsItem)
     allEventsItem.addActionListener(
       new ActionListener() {
-        def actionPerformed(ae: ActionEvent): Unit = {
+        def actionPerformed(ae: ActionEvent | Null): Unit = {
           viewOptions = eventTypesToCollect
           updateViewOptionsAndEventsList()
         }
@@ -746,9 +746,9 @@ private[scalatest] class RunnerJFrame(
 
       val itemAction: AbstractAction =
         new AbstractAction(menuItemText) {
-          def actionPerformed(ae: ActionEvent): Unit = {
+          def actionPerformed(ae: ActionEvent | Null): Unit = {
 
-            val checkBox: JCheckBoxMenuItem = ae.getSource().asInstanceOf[JCheckBoxMenuItem]
+            val checkBox: JCheckBoxMenuItem = ae.nn.getSource().asInstanceOf[JCheckBoxMenuItem]
             val option = getValue("option").asInstanceOf[EventToPresent]
 
             if (viewOptions.contains(option))

--- a/scalatest/src/main/scala/org/scalatest/tools/RunnerJFrame.scala
+++ b/scalatest/src/main/scala/org/scalatest/tools/RunnerJFrame.scala
@@ -319,7 +319,7 @@ private[scalatest] class RunnerJFrame(
               val (grayStackTraceElements, blackStackTraceElements) =
                 holder.throwable match {
                   case Some(throwable) =>
-                    val stackTraceElements = throwable.getStackTrace.toList
+                    val stackTraceElements = throwable.getStackTrace.map(_.nn).toList
                     throwable match {
                       case tfe: TestFailedException =>
                         (stackTraceElements.take(tfe.failedCodeStackDepth), stackTraceElements.drop(tfe.failedCodeStackDepth))
@@ -356,7 +356,7 @@ private[scalatest] class RunnerJFrame(
                 </table>
                 <table>
                 <tr valign="top">
-                <td align="left" colspan="2">{ getHTMLForStackTrace(cause.getStackTrace.toList) }</td>
+                <td align="left" colspan="2">{ getHTMLForStackTrace(cause.getStackTrace.map(_.nn).toList) }</td>
                 </tr>
                 </table> &+ getHTMLForCause(cause)
               }

--- a/scalatest/src/main/scala/org/scalatest/tools/ScalaTestAntTask.scala
+++ b/scalatest/src/main/scala/org/scalatest/tools/ScalaTestAntTask.scala
@@ -295,8 +295,8 @@ import org.apache.tools.ant.taskdefs.Java
 class ScalaTestAntTask extends Task {
   private var includes:  String = ""
   private var excludes:  String = ""
-  private var maxMemory: String = null
-  private var suffixes:  String = null
+  private var maxMemory: String | Null = null
+  private var suffixes:  String | Null = null
 
   private var parallel      = false
   private var sortSuites    = false
@@ -427,7 +427,7 @@ class ScalaTestAntTask extends Task {
   private def addSuffixesArg(args: ListBuffer[String]): Unit = {
     if (suffixes != null) {
       args += "-q"
-      args += suffixes
+      args += suffixes.nn
     }
   }
 
@@ -485,7 +485,7 @@ class ScalaTestAntTask extends Task {
         throw new BuildException(
           "missing classname attribute for <suite> element")
       args += "-s"
-      args += suite.getClassName
+      args += suite.getClassName.nn
       suite.getTestNames.foreach { tn => 
         if (tn == null)
           throw new BuildException("missing name attribute for <test> element")
@@ -496,7 +496,7 @@ class ScalaTestAntTask extends Task {
         if (ns.getSuiteId == null)
           throw new BuildException("missing suiteId attribute for <nested> element")
         args += "-i"
-        args += ns.getSuiteId
+        args += ns.getSuiteId.nn
         ns.getTestNames.foreach { tn => 
           if (tn == null)
             throw new BuildException("missing name attribute for <test> element")
@@ -531,11 +531,11 @@ class ScalaTestAntTask extends Task {
     for (test <- tests) {
       if (test.getName != null) {
         args += "-t"
-        args += test.getName
+        args += test.getName.nn
       }
       else if (test.getSubstring != null) {
         args += "-z"
-        args += test.getSubstring
+        args += test.getSubstring.nn
       }
       else
         throw new BuildException(
@@ -599,7 +599,7 @@ class ScalaTestAntTask extends Task {
       throw new BuildException(
         "reporter type 'file' requires 'filename' attribute")
 
-    args += reporter.getFilename
+    args += reporter.getFilename.nn
   }
 
   //
@@ -615,7 +615,7 @@ class ScalaTestAntTask extends Task {
       throw new BuildException(
         "reporter type 'memory' requires 'filename' attribute")
 
-    args += reporter.getFilename
+    args += reporter.getFilename.nn
   }
 
   //
@@ -632,7 +632,7 @@ class ScalaTestAntTask extends Task {
       throw new BuildException(
         "reporter type 'xml' requires 'directory' attribute")
 
-    args += reporter.getDirectory
+    args += reporter.getDirectory.nn
   }
 
   //
@@ -648,7 +648,7 @@ class ScalaTestAntTask extends Task {
       throw new BuildException(
         "reporter type 'junitxml' requires 'directory' attribute")
 
-    args += reporter.getDirectory
+    args += reporter.getDirectory.nn
   }
 
   //
@@ -664,7 +664,7 @@ class ScalaTestAntTask extends Task {
       throw new BuildException(
         "reporter type 'dashboard' requires 'directory' attribute")
 
-    args += reporter.getDirectory
+    args += reporter.getDirectory.nn
 
     if (reporter.getNumfiles >= 0) {
       args += "-a"
@@ -686,11 +686,11 @@ class ScalaTestAntTask extends Task {
       throw new BuildException(
         "reporter type 'html' requires 'directory' attribute")
 
-    args += reporter.getDirectory
+    args += reporter.getDirectory.nn
     
     if (reporter.getCss != null) {
       args += "-Y"
-      args += reporter.getCss
+      args += reporter.getCss.nn
     }
   }
 
@@ -709,14 +709,14 @@ class ScalaTestAntTask extends Task {
       throw new BuildException(
         "reporter type 'reporterclass' requires 'classname' attribute")
 
-    args += reporter.getClassName
+    args += reporter.getClassName.nn
   }
 
   /**
    * Sets value of the <code>runpath</code> attribute.
    */
   def setRunpath(runpath: Path): Unit = {
-    for (element <- runpath.list) {
+    for (element <- runpath.list.map(_.nn)) {
       this.runpath += element
     }
   }
@@ -774,7 +774,7 @@ class ScalaTestAntTask extends Task {
    * Sets value of the <code>testngsuites</code> attribute.
    */
   def setTestNGSuites(testNGSuitePath: Path): Unit = {
-    for (element <- testNGSuitePath.list)
+    for (element <- testNGSuitePath.list.map(_.nn))
       this.testNGSuites += element
   }
 
@@ -810,7 +810,7 @@ class ScalaTestAntTask extends Task {
    * Sets value from nested element <code>runpath</code>.
    */
   def addConfiguredRunpath(runpath: Path): Unit = {
-    for (element <- runpath.list)
+    for (element <- runpath.list.map(_.nn))
       this.runpath += element
   }
  
@@ -818,7 +818,7 @@ class ScalaTestAntTask extends Task {
    * Sets value from nested element <code>testngsuites</code>.
    */
   def addConfiguredTestNGSuites(testNGSuitePath: Path): Unit = {
-    for (element <- testNGSuitePath.list)
+    for (element <- testNGSuitePath.list.map(_.nn))
       this.testNGSuites += element
   }
 
@@ -826,14 +826,14 @@ class ScalaTestAntTask extends Task {
    * Sets value from nested element <code>runpathurl</code>.
    */
   def addConfiguredRunpathUrl(runpathurl: RunpathUrl): Unit = {
-    runpath += runpathurl.getUrl
+    runpath += runpathurl.getUrl.nn
   }
 
   /**
    * Sets value from nested element <code>jvmarg</code>.
    */
   def addConfiguredJvmArg(arg: JvmArg): Unit = {
-    jvmArgs += arg.getValue
+    jvmArgs += arg.getValue.nn
   }
 
   /**
@@ -889,14 +889,14 @@ class ScalaTestAntTask extends Task {
    * Sets value from nested element <code>membersonly</code>.
    */
   def addConfiguredMembersOnly(membersonly: PackageElement): Unit = {
-    membersonlys += membersonly.getPackage
+    membersonlys += membersonly.getPackage.nn
   }
 
   /**
    * Sets value from nested element <code>wildcard</code>.
    */
   def addConfiguredWildcard(wildcard: PackageElement): Unit = {
-    wildcards += wildcard.getPackage
+    wildcards += wildcard.getPackage.nn
   }
 
   /**
@@ -914,14 +914,14 @@ class ScalaTestAntTask extends Task {
   }
   
   def addConfiguredStyle(style: StyleElement): Unit = {
-    this.chosenStyles += style.getName
+    this.chosenStyles += style.getName.nn
   }
 
   /**
    * Sets value from nested element <code>testsfile</code>.
    */
   def addConfiguredTestsfile(testsfile: TestsfileElement): Unit = {
-    this.testsfiles += testsfile.getFilename
+    this.testsfiles += testsfile.getFilename.nn
   }
 
   /**
@@ -956,7 +956,7 @@ class ScalaTestAntTask extends Task {
   // Class to hold data from <style> elements.
   //
   private class StyleElement {
-    private var name: String = null
+    private var name: String | Null = null
     
     def setName(name: String): Unit = {
       this.name = name
@@ -969,7 +969,7 @@ class ScalaTestAntTask extends Task {
   // Class to hold data from <testsfile> elements.
   //
   private class TestsfileElement {
-    private var filename: String = null
+    private var filename: String | Null = null
     
     def setFilename(filename: String): Unit = {
       this.filename = filename
@@ -982,7 +982,7 @@ class ScalaTestAntTask extends Task {
   // Class to hold data from <membersonly> and <wildcard> elements.
   //
   private class PackageElement {
-    private var packageName: String = null
+    private var packageName: String | Null = null
 
     def setPackage(packageName: String): Unit = {
       this.packageName = packageName
@@ -995,7 +995,7 @@ class ScalaTestAntTask extends Task {
   // Class to hold data from <suite> elements.
   //
   private class SuiteElement {
-    private var className: String = null
+    private var className: String | Null = null
     private val testNamesBuffer = new ListBuffer[String]()
     private val nestedSuitesBuffer = new ListBuffer[NestedSuiteElement]()
     
@@ -1004,7 +1004,7 @@ class ScalaTestAntTask extends Task {
     }
 
     def addConfiguredTest(test: TestElement): Unit = {
-      testNamesBuffer += test.getName
+      testNamesBuffer += test.getName.nn
     }
     
     def addConfiguredNested(nestedSuite: NestedSuiteElement): Unit = {
@@ -1017,8 +1017,8 @@ class ScalaTestAntTask extends Task {
   }
   
   private[tools] class TestElement {
-    private var name: String = null
-    private var substring: String = null
+    private var name: String | Null = null
+    private var substring: String | Null = null
     
     def setName(name: String): Unit = {
       this.name = name
@@ -1033,7 +1033,7 @@ class ScalaTestAntTask extends Task {
   }
   
   private class NestedSuiteElement {
-    private var suiteId: String = null
+    private var suiteId: String | Null = null
     private val testNamesBuffer = new ListBuffer[String]()
     
     def setSuiteId(suiteId: String): Unit = {
@@ -1041,7 +1041,7 @@ class ScalaTestAntTask extends Task {
     }
     
     def addConfiguredTest(test: TestElement): Unit = {
-      testNamesBuffer += test.getName
+      testNamesBuffer += test.getName.nn
     }
     
     def getSuiteId = suiteId
@@ -1052,7 +1052,7 @@ class ScalaTestAntTask extends Task {
   // Class to hold data from tagsToInclude and tagsToExclude elements.
   //
   private class TextElement {
-      private var text: String = null
+      private var text: String | Null = null
 
       def addText(text: String): Unit = {
         this.text = text
@@ -1065,8 +1065,8 @@ class ScalaTestAntTask extends Task {
   // Class to hold data from <property> elements.
   //
   private class NameValuePair {
-    private var name  : String = null
-    private var value : String = null
+    private var name  : String | Null = null
+    private var value : String | Null = null
 
     def setName(name   : String): Unit = { this.name  = name  }
     def setValue(value : String): Unit = { this.value = value }
@@ -1079,7 +1079,7 @@ class ScalaTestAntTask extends Task {
   // Class to hold data from <runpathurl> elements.
   //
   private class RunpathUrl {
-    private var url: String = null
+    private var url: String | Null = null
 
     def setUrl(url: String): Unit = { this.url = url }
     def getUrl = url
@@ -1089,7 +1089,7 @@ class ScalaTestAntTask extends Task {
   // Class to hold data from <jvmarg> elements.
   //
   private class JvmArg {
-    private var value: String = null
+    private var value: String | Null = null
 
     def setValue(value: String): Unit = { this.value = value }
     def getValue = value
@@ -1099,13 +1099,13 @@ class ScalaTestAntTask extends Task {
   // Class to hold data from <reporter> elements.
   //
   private class ReporterElement {
-    private var rtype     : String = null
-    private var config    : String = null
-    private var filename  : String = null
-    private var directory : String = null
-    private var classname : String = null
+    private var rtype     : String | Null = null
+    private var config    : String | Null = null
+    private var filename  : String | Null = null
+    private var directory : String | Null = null
+    private var classname : String | Null = null
     private var numfiles  : Int    = -1
-    private var css       : String = null
+    private var css       : String | Null = null
 
     def setType(rtype          : String): Unit = { this.rtype     = rtype     }
     def setConfig(config       : String): Unit = { this.config    = config    }

--- a/scalatest/src/main/scala/org/scalatest/tools/ScalaTestFramework.scala
+++ b/scalatest/src/main/scala/org/scalatest/tools/ScalaTestFramework.scala
@@ -18,6 +18,7 @@ package org.scalatest.tools
 import org.scalatest._
 import ArgsParser._
 import SuiteDiscoveryHelper._
+import java.lang.reflect.Constructor
 import java.util.concurrent.atomic.AtomicBoolean
 import java.util.concurrent.atomic.AtomicInteger
 import java.util.concurrent.atomic.AtomicLong
@@ -430,7 +431,7 @@ Tags to include and exclude: -n "CheckinTests FunctionalTests" -l "SlowTests Net
               suiteClass.newInstance.asInstanceOf[Suite]
             else {
               val suiteClazz = wrapWithAnnotation.value
-              val constructorList = suiteClazz.getDeclaredConstructors()
+              val constructorList : Array[Constructor[_]] = suiteClazz.getDeclaredConstructors().map(_.nn)
               val constructor = constructorList.find { c => 
                   val types = c.getParameterTypes
                   types.length == 1 && types(0) == classOf[java.lang.Class[_]]

--- a/scalatest/src/main/scala/org/scalatest/tools/ScalaTestFramework.scala
+++ b/scalatest/src/main/scala/org/scalatest/tools/ScalaTestFramework.scala
@@ -118,7 +118,7 @@ class ScalaTestFramework extends SbtFramework {
         def annotationName = "org.scalatest.WrapWith"
         def isModule = false
       }
-    )
+    ).asInstanceOf[Array[Fingerprint | Null]]
     
   private[scalatest] object RunConfig {
 
@@ -316,8 +316,8 @@ class ScalaTestFramework extends SbtFramework {
    * Returns an <code>org.scalatools.testing.Runner</code> that will load test classes via the passed <code>testLoader</code>
    * and direct output from running the tests to the passed array of <code>Logger</code>s.
    */
-  def testRunner(testLoader: ClassLoader, loggers: Array[Logger]) = {
-    new ScalaTestRunner(testLoader, loggers)
+  def testRunner(testLoader: ClassLoader | Null, loggers: Array[Logger | Null] | Null) = {
+    new ScalaTestRunner(testLoader.nn, loggers.nn.map(_.nn))
   }
   
   private[scalatest] class SbtLogInfoReporter(
@@ -411,13 +411,15 @@ Tags to include and exclude: -n "CheckinTests FunctionalTests" -l "SlowTests Net
     private def filterMembersOnly(paths: List[String], testClassName: String): Boolean =
       paths.exists(path => testClassName.startsWith(path) && testClassName.substring(path.length ).lastIndexOf('.') <= 0)
       
-    def run(testClassName: String, fingerprint: Fingerprint, eventHandler: EventHandler, args: Array[String]): Unit = {
+    def run(_testClassName: String | Null, fingerprint: Fingerprint | Null, _eventHandler: EventHandler | Null, args: Array[String | Null] | Null): Unit = {
+      val testClassName = _testClassName.nn
+      val eventHandler = _eventHandler.nn
       try {
         RunConfig.increaseLatch()
         val suiteClass = Class.forName(testClassName, true, testLoader)
         //println("sbt args: " + args.toList)
         if ((isAccessibleSuite(suiteClass) || isRunnable(suiteClass)) && isDiscoverableSuite(suiteClass)) {
-          val (reporter, filter, configMap, membersOnly, wildcard, testSortingReporterTimeout) = RunConfig.getConfigurations(args, loggers, eventHandler, testLoader)
+          val (reporter, filter, configMap, membersOnly, wildcard, testSortingReporterTimeout) = RunConfig.getConfigurations(args.nn.map(_.nn), loggers, eventHandler, testLoader)
           
           if ((wildcard.isEmpty && membersOnly.isEmpty) || filterWildcard(wildcard, testClassName) || filterMembersOnly(membersOnly, testClassName)) {
           
@@ -500,7 +502,7 @@ Tags to include and exclude: -n "CheckinTests FunctionalTests" -l "SlowTests Net
             def testName = tn
             def description = tn
             def result = r
-            def error = e getOrElse null
+            def error = (e getOrElse null).asInstanceOf[Throwable]
           }
         )
       }

--- a/scalatest/src/main/scala/org/scalatest/tools/SuiteDiscoveryHelper.scala
+++ b/scalatest/src/main/scala/org/scalatest/tools/SuiteDiscoveryHelper.scala
@@ -16,6 +16,7 @@
 package org.scalatest.tools
 
 import org.scalatest._
+import java.lang.reflect.Constructor
 import java.lang.reflect.Modifier
 import java.util.Enumeration
 import java.util.jar.JarFile
@@ -213,7 +214,7 @@ private[scalatest] object SuiteDiscoveryHelper {
     val wrapWithAnnotation = clazz.getAnnotation(classOf[WrapWith])
     if (wrapWithAnnotation != null) {
       val wrapperSuiteClazz = wrapWithAnnotation.value
-      val constructorList = wrapperSuiteClazz.getDeclaredConstructors()
+      val constructorList : Array[Constructor[_]] = wrapperSuiteClazz.getDeclaredConstructors().map(_.nn)
       constructorList.exists { c => 
         val types = c.getParameterTypes
         types.length == 1 && types(0) == classOf[java.lang.Class[_]]
@@ -294,13 +295,13 @@ private[scalatest] object SuiteDiscoveryHelper {
       if (!dir.isDirectory)
         throw new IllegalArgumentException
 
-      val subDirs = for (entry <- dir.listFiles.toList; if entry.isDirectory) yield entry
+      val subDirs = for (entry <- dir.listFiles.toList.map(_.nn); if entry.isDirectory) yield entry
       val fileLists: List[List[String]] = 
         for (subDir <- subDirs) 
           yield listFilesInDir(subDir, prependPrevName(prevName, subDir.getName))
 
       val files: List[String] =
-        for (entry <- dir.listFiles.toList; if !entry.isDirectory)
+        for (entry <- dir.listFiles.toList.map(_.nn); if !entry.isDirectory)
           yield prependPrevName(prevName, entry.getName)
 
       files ::: fileLists.flatMap(e => e)

--- a/scalatest/src/main/scala/org/scalatest/tools/SuiteRunner.scala
+++ b/scalatest/src/main/scala/org/scalatest/tools/SuiteRunner.scala
@@ -68,9 +68,9 @@ private[scalatest] class SuiteRunner(suite: Suite, args: Args, status: ScalaTest
       }
       catch {
         case e: NotAllowedException =>
-          val formatter = Suite.formatterForSuiteAborted(suite, e.getMessage)
+          val formatter = Suite.formatterForSuiteAborted(suite, e.getMessage.nn).nn
           val duration = System.currentTimeMillis - suiteStartTime
-          dispatch(SuiteAborted(tracker.nextOrdinal(), e.getMessage, suite.suiteName, suite.suiteId, Some(suite.getClass.getName), Some(e), Some(duration), formatter, Some(SeeStackDepthException), suite.rerunner))
+          dispatch(SuiteAborted(tracker.nextOrdinal(), e.getMessage.nn, suite.suiteName, suite.suiteId, Some(suite.getClass.getName), Some(e), Some(duration), formatter, Some(SeeStackDepthException), suite.rerunner))
           status.setFailed()
           status.setCompleted()
         case e: RuntimeException => { // Do fire SuiteAborted even if a DistributedTestRunnerSuite 

--- a/scalatest/src/main/scala/org/scalatest/wordspec/AnyWordSpecLike.scala
+++ b/scalatest/src/main/scala/org/scalatest/wordspec/AnyWordSpecLike.scala
@@ -191,7 +191,7 @@ trait AnyWordSpecLike extends TestSuite with TestRegistration with ShouldVerb wi
       case e: TestCanceledException => throw new NotAllowedException(FailureMessages.assertionShouldBePutInsideItOrTheyClauseNotShouldMustWhenThatWhichOrCanClause, Some(e), e.position.getOrElse(pos))
       case nae: NotAllowedException => throw nae
       case trce: TestRegistrationClosedException => throw trce
-      case e: DuplicateTestNameException => throw new NotAllowedException(exceptionWasThrownInClauseMessageFun(verb, UnquotedString(e.getClass.getName), description, e.getMessage), Some(e), e.position.getOrElse(pos))
+      case e: DuplicateTestNameException => throw new NotAllowedException(exceptionWasThrownInClauseMessageFun(verb, UnquotedString(e.getClass.getName), description, e.getMessage.nn), Some(e), e.position.getOrElse(pos))
       case other: Throwable if (!Suite.anExceptionThatShouldCauseAnAbort(other)) => throw new NotAllowedException(exceptionWasThrownInClauseMessageFun(verb, UnquotedString(other.getClass.getName), if (description.endsWith(" " + verb)) description.substring(0, description.length - (" " + verb).length) else description, other.getMessage), Some(other), pos)
       case other: Throwable => throw other
     }
@@ -225,7 +225,7 @@ trait AnyWordSpecLike extends TestSuite with TestRegistration with ShouldVerb wi
                 case e: TestCanceledException => throw new NotAllowedException(FailureMessages.assertionShouldBePutInsideItOrTheyClauseNotShouldMustWhenThatWhichOrCanClause, Some(e), e.position.getOrElse(pos))
                 case nae: NotAllowedException => throw nae
                 case trce: TestRegistrationClosedException => throw trce
-                case e: DuplicateTestNameException => throw new NotAllowedException(exceptionWasThrownInClauseMessageFun(methodName, UnquotedString(e.getClass.getName), descriptionText, e.getMessage), Some(e), e.position.getOrElse(pos))
+                case e: DuplicateTestNameException => throw new NotAllowedException(exceptionWasThrownInClauseMessageFun(methodName, UnquotedString(e.getClass.getName), descriptionText, e.getMessage.nn), Some(e), e.position.getOrElse(pos))
                 case other: Throwable if (!Suite.anExceptionThatShouldCauseAnAbort(other)) => throw new NotAllowedException(exceptionWasThrownInClauseMessageFun(methodName, UnquotedString(other.getClass.getName), if (descriptionText.endsWith(" " + methodName)) descriptionText.substring(0, descriptionText.length - (" " + methodName).length) else descriptionText, other.getMessage), Some(other), pos)
                 case other: Throwable => throw other
               }

--- a/scalatest/src/main/scala/org/scalatest/wordspec/AsyncWordSpecLike.scala
+++ b/scalatest/src/main/scala/org/scalatest/wordspec/AsyncWordSpecLike.scala
@@ -196,7 +196,7 @@ trait AsyncWordSpecLike extends AsyncTestSuite with AsyncTestRegistration with S
       case e: TestCanceledException => throw new NotAllowedException(FailureMessages.assertionShouldBePutInsideItOrTheyClauseNotShouldMustWhenThatWhichOrCanClause, Some(e), e.position.getOrElse(pos))
       case nae: NotAllowedException => throw nae
       case trce: TestRegistrationClosedException => throw trce
-      case e: DuplicateTestNameException => throw new NotAllowedException(exceptionWasThrownInClauseMessageFun(verb, UnquotedString(e.getClass.getName), description, e.getMessage), Some(e), e.position.getOrElse(pos))
+      case e: DuplicateTestNameException => throw new NotAllowedException(exceptionWasThrownInClauseMessageFun(verb, UnquotedString(e.getClass.getName), description, e.getMessage.nn), Some(e), e.position.getOrElse(pos))
       case other: Throwable if (!Suite.anExceptionThatShouldCauseAnAbort(other)) => throw new NotAllowedException(exceptionWasThrownInClauseMessageFun(verb, UnquotedString(other.getClass.getName), if (description.endsWith(" " + verb)) description.substring(0, description.length - (" " + verb).length) else description, other.getMessage), Some(other), pos)
       case other: Throwable => throw other
     }
@@ -230,7 +230,7 @@ trait AsyncWordSpecLike extends AsyncTestSuite with AsyncTestRegistration with S
                 case e: TestCanceledException => throw new NotAllowedException(FailureMessages.assertionShouldBePutInsideItOrTheyClauseNotShouldMustWhenThatWhichOrCanClause, Some(e), e.position.getOrElse(pos))
                 case nae: NotAllowedException => throw nae
                 case trce: TestRegistrationClosedException => throw trce
-                case e: DuplicateTestNameException => throw new NotAllowedException(exceptionWasThrownInClauseMessageFun(methodName, UnquotedString(e.getClass.getName), descriptionText, e.getMessage), Some(e), e.position.getOrElse(pos))
+                case e: DuplicateTestNameException => throw new NotAllowedException(exceptionWasThrownInClauseMessageFun(methodName, UnquotedString(e.getClass.getName), descriptionText, e.getMessage.nn), Some(e), e.position.getOrElse(pos))
                 case other: Throwable if (!Suite.anExceptionThatShouldCauseAnAbort(other)) => throw new NotAllowedException(exceptionWasThrownInClauseMessageFun(methodName, UnquotedString(other.getClass.getName), if (descriptionText.endsWith(" " + methodName)) descriptionText.substring(0, descriptionText.length - (" " + methodName).length) else descriptionText, other.getMessage), Some(other), pos)
                 case other: Throwable => throw other
               }

--- a/scalatest/src/main/scala/org/scalatest/wordspec/FixtureAnyWordSpecLike.scala
+++ b/scalatest/src/main/scala/org/scalatest/wordspec/FixtureAnyWordSpecLike.scala
@@ -211,7 +211,7 @@ trait FixtureAnyWordSpecLike extends org.scalatest.FixtureTestSuite with org.sca
       case e: TestCanceledException => throw new NotAllowedException(FailureMessages.assertionShouldBePutInsideItOrTheyClauseNotShouldMustWhenThatWhichOrCanClause, Some(e), e.position.getOrElse(pos))
       case nae: NotAllowedException => throw nae
       case trce: TestRegistrationClosedException => throw trce
-      case e: DuplicateTestNameException => throw new NotAllowedException(exceptionWasThrownInClauseMessageFun(verb, UnquotedString(e.getClass.getName), description, e.getMessage), Some(e), e.position.getOrElse(pos))
+      case e: DuplicateTestNameException => throw new NotAllowedException(exceptionWasThrownInClauseMessageFun(verb, UnquotedString(e.getClass.getName), description, e.getMessage.nn), Some(e), e.position.getOrElse(pos))
       case other: Throwable if (!Suite.anExceptionThatShouldCauseAnAbort(other)) => throw new NotAllowedException(exceptionWasThrownInClauseMessageFun(verb, UnquotedString(other.getClass.getName), if (description.endsWith(" " + verb)) description.substring(0, description.length - (" " + verb).length) else description, other.getMessage), Some(other), pos)
       case other: Throwable => throw other
     }
@@ -245,7 +245,7 @@ trait FixtureAnyWordSpecLike extends org.scalatest.FixtureTestSuite with org.sca
                 case e: TestCanceledException => throw new NotAllowedException(FailureMessages.assertionShouldBePutInsideItOrTheyClauseNotShouldMustWhenThatWhichOrCanClause, Some(e), e.position.getOrElse(pos))
                 case nae: NotAllowedException => throw nae
                 case trce: TestRegistrationClosedException => throw trce
-                case e: DuplicateTestNameException => throw new NotAllowedException(exceptionWasThrownInClauseMessageFun(methodName, UnquotedString(e.getClass.getName), descriptionText, e.getMessage), Some(e), e.position.getOrElse(pos))
+                case e: DuplicateTestNameException => throw new NotAllowedException(exceptionWasThrownInClauseMessageFun(methodName, UnquotedString(e.getClass.getName), descriptionText, e.getMessage.nn), Some(e), e.position.getOrElse(pos))
                 case other: Throwable if (!Suite.anExceptionThatShouldCauseAnAbort(other)) => throw new NotAllowedException(exceptionWasThrownInClauseMessageFun(methodName, UnquotedString(other.getClass.getName), if (descriptionText.endsWith(" " + methodName)) descriptionText.substring(0, descriptionText.length - (" " + methodName).length) else descriptionText, other.getMessage), Some(other), pos)
                 case other: Throwable => throw other
               }

--- a/scalatest/src/main/scala/org/scalatest/wordspec/FixtureAsyncWordSpecLike.scala
+++ b/scalatest/src/main/scala/org/scalatest/wordspec/FixtureAsyncWordSpecLike.scala
@@ -187,7 +187,7 @@ trait FixtureAsyncWordSpecLike extends org.scalatest.FixtureAsyncTestSuite with 
       case e: TestCanceledException => throw new NotAllowedException(FailureMessages.assertionShouldBePutInsideItOrTheyClauseNotShouldMustWhenThatWhichOrCanClause, Some(e), e.position.getOrElse(pos))
       case nae: NotAllowedException => throw nae
       case trce: TestRegistrationClosedException => throw trce
-      case e: DuplicateTestNameException => throw new NotAllowedException(exceptionWasThrownInClauseMessageFun(verb, UnquotedString(e.getClass.getName), description, e.getMessage), Some(e), e.position.getOrElse(pos))
+      case e: DuplicateTestNameException => throw new NotAllowedException(exceptionWasThrownInClauseMessageFun(verb, UnquotedString(e.getClass.getName), description, e.getMessage.nn), Some(e), e.position.getOrElse(pos))
       case other: Throwable if (!Suite.anExceptionThatShouldCauseAnAbort(other)) => throw new NotAllowedException(exceptionWasThrownInClauseMessageFun(verb, UnquotedString(other.getClass.getName), if (description.endsWith(" " + verb)) description.substring(0, description.length - (" " + verb).length) else description, other.getMessage), Some(other), pos)
       case other: Throwable => throw other
     }
@@ -221,7 +221,7 @@ trait FixtureAsyncWordSpecLike extends org.scalatest.FixtureAsyncTestSuite with 
                 case e: TestCanceledException => throw new NotAllowedException(FailureMessages.assertionShouldBePutInsideItOrTheyClauseNotShouldMustWhenThatWhichOrCanClause, Some(e), e.position.getOrElse(pos))
                 case nae: NotAllowedException => throw nae
                 case trce: TestRegistrationClosedException => throw trce
-                case e: DuplicateTestNameException => throw new NotAllowedException(exceptionWasThrownInClauseMessageFun(methodName, UnquotedString(e.getClass.getName), descriptionText, e.getMessage), Some(e), e.position.getOrElse(pos))
+                case e: DuplicateTestNameException => throw new NotAllowedException(exceptionWasThrownInClauseMessageFun(methodName, UnquotedString(e.getClass.getName), descriptionText, e.getMessage.nn), Some(e), e.position.getOrElse(pos))
                 case other: Throwable if (!Suite.anExceptionThatShouldCauseAnAbort(other)) => throw new NotAllowedException(exceptionWasThrownInClauseMessageFun(methodName, UnquotedString(other.getClass.getName), if (descriptionText.endsWith(" " + methodName)) descriptionText.substring(0, descriptionText.length - (" " + methodName).length) else descriptionText, other.getMessage), Some(other), pos)
                 case other: Throwable => throw other
               }


### PR DESCRIPTION
LOC changed: 207

**Nullable variable** | 42
Variables that really can be null and should therefore have a `| Null` type.

**Nullable parameter** | 6
Parameter that can be null and should therefore have a `| Null` type.

**Nullable collection** | 1
Variables in collection type should be nullable. We use `new Collection[T | Null]` instead of `new Collection[T]`.

**Nullable variable is used** | 51
Requires `.nn` to remove nullness.

**Java method returns array | 49**
Java method returns array of type `Array[Null | T]`. We need to map it to `Array[T]`.

**Overridden java method arguments are nullable** | 30
A Scala method overrides some Java method. We need to add `|Null` to the method's parameter types to make the override still work.

**Overridden java arguments are never null** | 11
Argument should never be null, immediately remove nullness of parameter.

**Overridden java method returns array** | 1
Overridden java method returns an array. Java arrays have type `Array[T | Null]`. Returned array must thereby be converted to have type `Array[T | Null]`.

**Java method returns array** | 49
Java method returns array of type `Array[Null | T]`. We need to map it to `Array[T]`.

**Pass array into java method** | 2 
Pass `Array[T]` as argument to java method that requires an array. Java arrays have type `Array[T | Null]`.

**Overridden java array field** | 6
A Scala field overrides some Java array field. We need to use `Array[T | Null]` instead of `Array[T]` for the overriding to work.

**Overridden java method return type cannot be null** | 4
The nullness in the return type of all java methods are cast away by the `-Yjava-interop-dont-nullify-outermost` compiler flag. `asInstanceOf[A]` is used for return values of type `A | Null`.

**Java template class requires nullable type** | 3
In order for operator overrides to be valid, java templates classes must use `T | Null` for the type. The nullness is then cast away using `asInstanceOf[ClassName[T]]`.

**Compiler cannot infer type** | 2
Compiler cannot infer the type of a union type parameter, the type needs to be explicitly declared.

The following issues also resulted in specific errors but are not counted because they are already considered in a different category.

**Overridden java array contents are never null**
Overridden array field of type `Array[T | Null]` should have type `Array[T]`. Use `.map(_.nn)` to fix.
